### PR TITLE
Deprecate ioutil

### DIFF
--- a/bloomfilter.go
+++ b/bloomfilter.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 
 	"github.com/Workiva/go-datastructures/bitarray"
@@ -80,7 +79,7 @@ func FromBytes(b []byte) (*BloomFilter, error) {
 	numHashFunctions := int(numHashFuncByte)
 
 	// read bitarray capacity
-	numUint64Bytes, err := ioutil.ReadAll(io.LimitReader(reader, 4))
+	numUint64Bytes, err := io.ReadAll(io.LimitReader(reader, 4))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read number of bits: %v", err)
 	}
@@ -92,7 +91,7 @@ func FromBytes(b []byte) (*BloomFilter, error) {
 
 	// put blocks back to bitarray
 	for blockIdx := 0; blockIdx < int(numUint64); blockIdx++ {
-		block, err := ioutil.ReadAll(io.LimitReader(reader, 8))
+		block, err := io.ReadAll(io.LimitReader(reader, 8))
 		if err != nil {
 			return nil, fmt.Errorf("Failed to build bitarray: %v", err)
 		}

--- a/bloomfilter_test.go
+++ b/bloomfilter_test.go
@@ -2,7 +2,7 @@ package bloomfilter
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -136,7 +136,7 @@ func TestBloomFilterSerialization(t *testing.T) {
 func TestJavaCompatibility(t *testing.T) {
 	file1, _ := os.Open("guava_dump_files/100_0_001_0_to_49_test.dump")
 	defer file1.Close()
-	b, _ := ioutil.ReadAll(file1)
+	b, _ := io.ReadAll(file1)
 	bf1, err := FromBytes(b)
 	if err != nil {
 		t.Errorf("Deserialization from Guava dump file failed: %v", err)
@@ -154,7 +154,7 @@ func TestJavaCompatibility(t *testing.T) {
 
 	file2, _ := os.Open("guava_dump_files/500_0_01_0_to_99_test.dump")
 	defer file1.Close()
-	b, _ = ioutil.ReadAll(file2)
+	b, _ = io.ReadAll(file2)
 	bf2, err := FromBytes(b)
 	if err != nil {
 		t.Errorf("Deserialization from Guava dump file failed: %v", err)
@@ -223,7 +223,7 @@ func BenchmarkBloomfilterQuery(b *testing.B) {
 	}
 }
 
-var fileContent, _ = ioutil.ReadFile("guava_dump_files/100_0_001_0_to_49_test.dump")
+var fileContent, _ = os.ReadFile("guava_dump_files/100_0_001_0_to_49_test.dump")
 
 func BenchmarkBloomfilterDeserialization(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
As mentioned in the [document](https://pkg.go.dev/io/ioutil),

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.