### PR TITLE
remove cgo dependency

### DIFF
--- a/bloomfilter.go
+++ b/bloomfilter.go
@@ -1,9 +1,5 @@
 package bloomfilter
 
-// #cgo CFLAGS: -Wall
-// #cgo LDFLAGS: -lm
-// #include<math.h>
-import "C"
 import (
 	"bytes"
 	"encoding/binary"
@@ -145,12 +141,9 @@ func numOfBits(expectedInsertions int, errRate float64) int {
 	if errRate == 0.0 {
 		errRate = math.Pow(2.0, -1074.0) // the same number of Double.MIN_VALUE in Java
 	}
-	errorRate := C.double(errRate)
-	// Use C functions to calculate logarithm here since Go's built-in math lib doesn't give accurate result.
-	// See https://github.com/golang/go/issues/9546 for details.
-	return int(C.double(-expectedInsertions) * C.log(errorRate) / (C.log(C.double(2.0)) * C.log(C.double(2.0))))
+	return int(float64(-expectedInsertions) * math.Log(errRate) / (math.Log(2.0) * math.Log(2.0)))
 }
 
 func numOfHashFunctions(expectedInsertions int, numBits int) int {
-	return int(math.Max(1.0, float64(C.round(C.double(numBits)/C.double(expectedInsertions)*C.log(C.double(2.0))))))
+	return int(math.Max(1.0, math.Round(float64(numBits)/float64(expectedInsertions)*math.Log(2.0))))
 }


### PR DESCRIPTION
Since `Hinge/backend` doesn't play nice with CGO, nor do we want to take on the complexity of enabling it, we have forked `OldPanda/bloomfiler` to remove the CGO dependency. This PR does that! 

I've gone ahead and run all my false/true positive analyses we did for the original repo on this fork and everything looks good. No false negatives and the false positive rate is maintained at 0.01% which we are comfortable with.  

We've also confirmed that the Guava library relies on the serialized header values when deciding numHashFunctions and numBits when [deserializing the bloom filter in Kotlin](https://guava.dev/releases/23.0/api/docs/src-html/com/google/common/hash/BloomFilter.html#line.587)

PR in the `OldPanda/bloomfiler` repo that we're copying in this PR: https://github.com/OldPanda/bloomfilter/pull/13